### PR TITLE
Fix `copy code` function

### DIFF
--- a/src/hooks/use-markdown-processor.tsx
+++ b/src/hooks/use-markdown-processor.tsx
@@ -15,6 +15,7 @@ import {
   useEffect,
   useMemo,
   useState,
+  useRef,
 } from "react";
 import flattenChildren from "react-keyed-flatten-children";
 import rehypeHighlight from "rehype-highlight";
@@ -218,6 +219,7 @@ const CodeBlock = ({ children, className }: JSX.IntrinsicElements["code"]) => {
   const [copied, setCopied] = useState(false);
   const [showMermaidPreview, setShowMermaidPreview] = useState(false);
   const [showLatexPreview, setShowLatexPreview] = useState(false);
+  const ref = useRef<HTMLElement>(null);
 
   useEffect(() => {
     if (copied) {
@@ -234,7 +236,7 @@ const CodeBlock = ({ children, className }: JSX.IntrinsicElements["code"]) => {
 
     return (
       <>
-        <code className={`${className} flex-grow flex-shrink my-auto`}>
+        <code ref={ref} className={`${className} flex-grow flex-shrink my-auto`}>
           {children}
         </code>
         <div className="flex flex-col gap-1 flex-grow-0 flex-shrink-0">
@@ -244,8 +246,10 @@ const CodeBlock = ({ children, className }: JSX.IntrinsicElements["code"]) => {
             aria-label="copy code to clipboard"
             title="Copy code to clipboard"
             onClick={() => {
-              navigator.clipboard.writeText(children?.toString() ?? "");
-              setCopied(true);
+              if (ref.current) {
+                navigator.clipboard.writeText(ref.current.innerText ?? "");
+                setCopied(true);
+              }
             }}
           >
             {copied ? (


### PR DESCRIPTION
This PR fixes the copy code function as shared in https://github.com/skovy/llm-markdown/issues/3
(I'm not a React developer; so not sure if this is the optimum way to resolve this)